### PR TITLE
Add link to L2D handbook in header

### DIFF
--- a/inst/pkgdown/templates/header.html
+++ b/inst/pkgdown/templates/header.html
@@ -166,6 +166,9 @@
           <a class="nav-link" href="{{#site}}{{root}}{{/site}}profiles.html">{{ translate.LearnerProfiles }}</a>
         </li>
         {{/instructor}}
+        <li class="nav-item">
+          <a class="nav-link" href="https://learntodiscover.github.io/L2D-Handbook/" target="_blank" rel="noopener noreferrer">L2D Handbook</a>
+        </li>
       </ul>
     </div>
     <!--


### PR DESCRIPTION
Link to https://learntodiscover.github.io/L2D-Handbook/ in the header of each episode.
The handbook link will open in a new tab.

Fixes https://github.com/LearnToDiscover/sandpaper/issues/73